### PR TITLE
Fix queue reference is not set

### DIFF
--- a/internal/controller/queue_controller.go
+++ b/internal/controller/queue_controller.go
@@ -121,7 +121,7 @@ func (r *QueueReconciler) createSpotInterruption(ctx context.Context, obj spotha
 		},
 		Spec: *spec,
 	}
-	spec.Queue = spothandlerv1.QueueReference{Name: obj.Name}
+	spotInterruption.Spec.Queue = spothandlerv1.QueueReference{Name: obj.Name}
 	if err := ctrl.SetControllerReference(&obj, &spotInterruption, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set the controller reference from Queue to SpotInterruption: %w", err)
 	}

--- a/internal/controller/queue_controller_test.go
+++ b/internal/controller/queue_controller_test.go
@@ -38,10 +38,12 @@ var messageInstance1 string
 var messageInstance2 string
 
 var _ = Describe("Queue Controller", func() {
+	var queue spothandlerv1.Queue
+
 	BeforeEach(func() {
 		ctx := context.TODO()
 		By("Creating a Queue object")
-		queue := spothandlerv1.Queue{
+		queue = spothandlerv1.Queue{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-queue-",
 			},
@@ -87,6 +89,7 @@ var _ = Describe("Queue Controller", func() {
 			Expect(spotInterruption1.Spec.EventTimestamp.UTC()).To(Equal(time.Date(2021, 2, 3, 14, 5, 6, 0, time.UTC)))
 			Expect(spotInterruption1.Spec.InstanceID).To(Equal("i-00000000000000001"))
 			Expect(spotInterruption1.Spec.AvailabilityZone).To(Equal("us-east-2a"))
+			Expect(spotInterruption1.Spec.Queue.Name).To(Equal(queue.Name))
 
 			By("Checking if SpotInterruption#2 is created")
 			var spotInterruption2 spothandlerv1.SpotInterruption
@@ -100,6 +103,7 @@ var _ = Describe("Queue Controller", func() {
 			Expect(spotInterruption2.Spec.EventTimestamp.UTC()).To(Equal(time.Date(2021, 2, 3, 14, 5, 6, 0, time.UTC)))
 			Expect(spotInterruption2.Spec.InstanceID).To(Equal("i-00000000000000002"))
 			Expect(spotInterruption2.Spec.AvailabilityZone).To(Equal("us-east-2b"))
+			Expect(spotInterruption2.Spec.Queue.Name).To(Equal(queue.Name))
 
 			By("Checking if the queue becomes empty")
 			Expect(mockSQSClient.messages).To(BeEmpty())


### PR DESCRIPTION
When a SpotInterruption is created, spec.queue is not set. This will fix it.
