### PR TITLE
Fix QF1008 could remove embedded field

### DIFF
--- a/internal/controller/queue_controller.go
+++ b/internal/controller/queue_controller.go
@@ -125,7 +125,7 @@ func (r *QueueReconciler) createSpotInterruption(ctx context.Context, obj spotha
 	if err := ctrl.SetControllerReference(&obj, &spotInterruption, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set the controller reference from Queue to SpotInterruption: %w", err)
 	}
-	if err := r.Client.Create(ctx, &spotInterruption); err != nil {
+	if err := r.Create(ctx, &spotInterruption); err != nil {
 		return ctrlclient.IgnoreAlreadyExists(fmt.Errorf("failed to create a SpotInterruption: %w", err))
 	}
 	return nil

--- a/internal/controller/spotinterruption_controller.go
+++ b/internal/controller/spotinterruption_controller.go
@@ -63,7 +63,7 @@ func (r *SpotInterruptionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if !obj.Status.ReconciledAt.IsZero() {
 		expiry := obj.Status.ReconciledAt.Add(spotInterruptionRetentionPeriod)
 		if r.Clock.Now().After(expiry) {
-			if err := r.Client.Delete(ctx, &obj); err != nil {
+			if err := r.Delete(ctx, &obj); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete an expired SpotInterruption: %w", err)
 			}
 			logger.Info("Deleted an expired SpotInterruption", "reconciledAt", obj.Status.ReconciledAt.Format(time.RFC3339))


### PR DESCRIPTION
Fix https://github.com/int128/spot-handler/actions/runs/15671590117/job/44143566869?pr=242:

```
/home/runner/work/spot-handler/spot-handler/bin/golangci-lint run
Error: internal/controller/queue_controller.go:128:14: QF1008: could remove embedded field "Client" from selector (staticcheck)
	if err := r.Client.Create(ctx, &spotInterruption); err != nil {
	            ^
Error: internal/controller/spotinterruption_controller.go:66:16: QF1008: could remove embedded field "Client" from selector (staticcheck)
			if err := r.Client.Delete(ctx, &obj); err != nil {
			            ^
2 issues:
* staticcheck: 2
make: *** [Makefile:89: lint] Error 1
```